### PR TITLE
Rename `:>:` to `<>:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ object Author {
 
 To express "given a book, get the author && all the books written by them", looks like this:
 ```scala
-val getAuthorAndTheirBooks = Book.author :>: Author.books
+val getAuthorAndTheirBooks = Book.author <>: Author.books
 ```
 
 But how would you run this with an instance of Book that you have?

--- a/core/src/main/scala/decrel/syntax.scala
+++ b/core/src/main/scala/decrel/syntax.scala
@@ -29,7 +29,7 @@ trait syntax {
       RightOut
     ] = Relation.Composed.Single(left, right)
 
-    def :>:[LeftTree, LeftIn, LeftOut, ZippedOut](
+    def <>:[LeftTree, LeftIn, LeftOut, ZippedOut](
       left: LeftTree & Relation.Single[LeftIn, LeftOut]
     )(implicit
       ev: LeftOut <:< RightIn,
@@ -65,7 +65,7 @@ trait syntax {
       RightOut
     ] = Relation.Composed.Optional(left, right)
 
-    def :>:[LeftTree, LeftIn, LeftOut, ZippedOut](
+    def <>:[LeftTree, LeftIn, LeftOut, ZippedOut](
       left: LeftTree & Relation.Optional[LeftIn, LeftOut]
     )(implicit
       ev: LeftOut <:< RightIn,
@@ -102,7 +102,7 @@ trait syntax {
       CC
     ] = Relation.Composed.Many(left, right)
 
-    def :>:[LeftTree, LeftIn, LeftOutO, ZippedOut, CC[+A]](
+    def <>:[LeftTree, LeftIn, LeftOutO, ZippedOut, CC[+A]](
       left: LeftTree & Relation.Many[LeftIn, CC, LeftOutO]
     )(implicit
       ev: LeftOutO <:< RightIn,

--- a/core/src/test/scala/decrel/RelationSpec.scala
+++ b/core/src/test/scala/decrel/RelationSpec.scala
@@ -76,7 +76,7 @@ object RelationSpec extends ZIOSpecDefault {
             Baz,
             (Bar, Baz) // Output
           ] =
-            Foo.bar :>: Bar.baz
+            Foo.bar <>: Bar.baz
 
           val _: Relation[Foo, (Bar, Baz)] = composed
 
@@ -113,7 +113,7 @@ object RelationSpec extends ZIOSpecDefault {
             Foo,
             (Foo, Bar)
           ] =
-            Baz.foo :>: Foo.bar
+            Baz.foo <>: Foo.bar
 
           val _: Relation[Baz, Option[(Foo, Bar)]] = composed
 
@@ -152,7 +152,7 @@ object RelationSpec extends ZIOSpecDefault {
             (Foo, Baz),
             List
           ] =
-            Bar.foo :>: Foo.baz
+            Bar.foo <>: Foo.baz
 
           val _: Relation[Bar, List[(Foo, Baz)]] = composed
 
@@ -247,7 +247,7 @@ object RelationSpec extends ZIOSpecDefault {
             (Option[Foo], Option[Bar]),
             (Baz, Option[Foo], Option[Bar])
           ] =
-            Foo.baz :>: (Baz.foo & Baz.bar)
+            Foo.baz <>: (Baz.foo & Baz.bar)
 
           val _: Relation[Foo, (Baz, Option[Foo], Option[Bar])] = composed
 
@@ -286,7 +286,7 @@ object RelationSpec extends ZIOSpecDefault {
             (Baz, Option[Foo], Option[Bar]),
             (Foo, Baz, Option[Foo], Option[Bar])
           ] =
-            Foo.self & (Foo.baz :>: (Baz.foo & Baz.bar))
+            Foo.self & (Foo.baz <>: (Baz.foo & Baz.bar))
 
           val _: Relation[Foo, (Foo, Baz, Option[Foo], Option[Bar])] = composed
 
@@ -341,7 +341,7 @@ object RelationSpec extends ZIOSpecDefault {
             Foo,
             (Foo, Bar, Baz)
           ] =
-            Baz.foo :>: (Foo.bar & Foo.baz)
+            Baz.foo <>: (Foo.bar & Foo.baz)
 
           val _: Relation[Baz, Option[(Foo, Bar, Baz)]] = composed
 
@@ -380,7 +380,7 @@ object RelationSpec extends ZIOSpecDefault {
             Option[(Foo, Bar, Baz)],
             (Baz, Option[(Foo, Bar, Baz)])
           ] =
-            Baz.self & (Baz.foo :>: (Foo.bar & Foo.baz))
+            Baz.self & (Baz.foo <>: (Foo.bar & Foo.baz))
 
           val _: Relation[Baz, (Baz, Option[(Foo, Bar, Baz)])] = composed
 
@@ -437,7 +437,7 @@ object RelationSpec extends ZIOSpecDefault {
             (Foo, Bar, Baz),
             List
           ] =
-            Bar.foo :>: (Foo.bar & Foo.baz)
+            Bar.foo <>: (Foo.bar & Foo.baz)
 
           val _: Relation[Bar, List[(Foo, Bar, Baz)]] = composed
 
@@ -477,9 +477,39 @@ object RelationSpec extends ZIOSpecDefault {
             List[(Foo, Bar, Baz)],
             (Bar, List[(Foo, Bar, Baz)])
           ] =
-            Bar.self & (Bar.foo :>: (Foo.bar & Foo.baz))
+            Bar.self & (Bar.foo <>: (Foo.bar & Foo.baz))
 
           val _: Relation[Bar, (Bar, List[(Foo, Bar, Baz)])] = composed
+
+          assertCompletes
+        },
+        test("<>: and >>: has same operator precedence") {
+          val composed: Composed.Zipped[
+            Foo.bar.type & Relation.Single[Foo, Bar],
+            Foo,
+            Bar,
+            Composed.Single[
+              Foo.bar.type & Relation.Single[Foo, Bar],
+              Foo,
+              Bar,
+              Composed.Single[
+                Bar.baz.type & Relation.Single[Bar, Baz],
+                Bar,
+                Baz,
+                Baz.foo.type & Relation[Baz, Option[Foo]],
+                Baz,
+                Option[Foo]
+              ] & Relation[Bar, Option[Foo]],
+              Bar,
+              Option[Foo]
+            ],
+            Foo,
+            Option[Foo],
+            (Bar, Option[Foo])
+          ] =
+            Foo.bar <>: Bar.baz >>: Baz.foo
+
+          val _: Relation[Foo, (Bar, Option[Foo])] = composed
 
           assertCompletes
         }

--- a/mdoc/docs/README.md
+++ b/mdoc/docs/README.md
@@ -40,7 +40,7 @@ becomes
 
 ```scala
 for {
-  (rental, book, user) <- (Rental.fetch :>: (Rental.book & Rental.user)).toZIO(rentalId)
+  (rental, book, user) <- (Rental.fetch <>: (Rental.book & Rental.user)).toZIO(rentalId)
 
   // ... do something with 3 objets
 ```
@@ -49,7 +49,7 @@ for {
 
 ```scala
 for {
-  (rental, book, user) <- (Rental.fetch :>: (Rental.book & Rental.user)).toF(rentalId)
+  (rental, book, user) <- (Rental.fetch <>: (Rental.book & Rental.user)).toF(rentalId)
 
   // ... do something with 3 objets
 ```

--- a/scalacheck/src/test/scala/decrel/scalacheck/genSpec.scala
+++ b/scalacheck/src/test/scala/decrel/scalacheck/genSpec.scala
@@ -124,8 +124,8 @@ object genSpec extends Properties("Relations") {
     book.currentRental contains staticRentalId
   }
 
-  property("Composing with :>:") = forAll {
-    val relation    = Rental.fetch :>: Rental.book
+  property("Composing with <>:") = forAll {
+    val relation    = Rental.fetch <>: Rental.book
     val rentalIdGen = Gen.const(staticRentalId)
     rentalIdGen.expand(relation)
   } { case (rental, book) =>

--- a/ziotest/src/test/scala/decrel/ziotest/genSpec.scala
+++ b/ziotest/src/test/scala/decrel/ziotest/genSpec.scala
@@ -121,8 +121,8 @@ object genSpec extends ZIOSpecDefault {
           assert(book.currentRental)(isSome(equalTo(staticRentalId)))
         }
       },
-      test("Composing with :>:") {
-        val relation = Rental.fetch :>: Rental.book
+      test("Composing with <>:") {
+        val relation = Rental.fetch <>: Rental.book
 
         val staticRentalId = Rental.Id("foo")
         val rentalIdGen    = Gen.const(staticRentalId)
@@ -132,8 +132,8 @@ object genSpec extends ZIOSpecDefault {
           assert(book.currentRental)(isSome(equalTo(staticRentalId)))
         }
       },
-      test("Composing with :>:") {
-        val relation = Rental.fetch :>: Rental.book
+      test("Composing with <>:") {
+        val relation = Rental.fetch <>: Rental.book
 
         val staticRentalId = Rental.Id("foo")
         val rentalIdGen    = Gen.const(staticRentalId)

--- a/zquery/src/test/scala/decrel/reify/zqueryProofSpec.scala
+++ b/zquery/src/test/scala/decrel/reify/zqueryProofSpec.scala
@@ -326,11 +326,11 @@ object zqueryProofSpec extends ZIOSpecDefault {
             }
           }
         ),
-        suite(":>:")(
+        suite("<>:")(
           test("simple") {
             proofs.flatMap { proofs =>
               import proofs.*
-              val relation = Book.currentRental :>: Rental.book
+              val relation = Book.currentRental <>: Rental.book
               val result   = relation.toZIO(book1)
 
               assertZIO(result)(isSome(equalTo((rental1, book1)))) &&
@@ -351,7 +351,7 @@ object zqueryProofSpec extends ZIOSpecDefault {
               val cache = Cache.empty
                 .add(Book.fetch, book1.id, book1)
 
-              val relation = Book.currentRental :>: Rental.book
+              val relation = Book.currentRental <>: Rental.book
               val result   = relation.toZIO(book1, cache)
 
               assertZIO(result)(isSome(equalTo((rental1, book1)))) &&


### PR DESCRIPTION
`:>:` has higher precedence as `>>:` (see https://docs.scala-lang.org/tour/operators.html)
so it binds tighter. 

When composing relations, if the `:>:` and `>>:` held the same precedence, an expression containing any combination of those will have not required parenthesis. This is untrue however, so renaming `>>:` to `<>:` to make it usable without redundant parens.

Example:

- Before
```scala
Foo.bar :>: Bar.baz >>: Baz.foo // Doesn't compile!
Foo.bar :>: (Bar.baz >>: Baz.foo) // Requires parens to guarantee right associativity
```
- After
```scala
Foo.bar <>: Bar.baz >>: Baz.foo // Compiles
```